### PR TITLE
Fixed colab dependency versions

### DIFF
--- a/Colab_DAIN.ipynb
+++ b/Colab_DAIN.ipynb
@@ -42,7 +42,7 @@
         "Enhancement by [Styler00Dollar](https://github.com/styler00dollar) aka \"sudo rm -rf / --no-preserve-root#8353\" on discord and [Alpha](https://github.com/AlphaGit). Please do not run this command in your linux terminal. It's rather meant as a joke.\n",
         "\n",
         "A simple guide:\n",
-        "- Copy the .ipynb-file to your drive.\n",
+        "- Upload the ` .ipynb`  file to your Google Colab.\n",
         "- Create a folder inside of Google Drive named \"DAIN\"\n",
         "- Change the configurations in the next cell\n",
         "- Run cells one by one\n",
@@ -161,7 +161,9 @@
       "source": [
         "# Install dependencies.\n",
         "\n",
-        "This next step may take somewhere between 15-20 minutes. Run this only once at startup.\n"
+        "This next step may take somewhere between 15-20 minutes. Run this only once at startup.\n",
+        "\n",
+        "Look for the \"Finished installing dependencies\"  message."
       ]
     },
     {
@@ -172,8 +174,11 @@
         "colab": {}
       },
       "source": [
+        "!pip install torch==1.4.0+cu100 torchvision==0.5.0+cu100 -f https://download.pytorch.org/whl/torch_stable.html\n",
+        "!pip install scipy==1.1.0\n",
+        "\n",
         "from IPython.display import clear_output\n",
-        "!git clone https://github.com/styler00dollar/Colab-DAIN /content/DAIN\n",
+        "!git clone https://github.com/baowenbo/DAIN /content/DAIN\n",
         "\n",
         "# This takes a while. Just wait. ~15 minutes.\n",
         "# Building DAIN.\n",
@@ -194,7 +199,9 @@
         "\n",
         "!CUDA_VISIBLE_DEVICES=0\n",
         "\n",
-        "!sudo apt-get install imagemagick imagemagick-doc"
+        "!sudo apt-get install imagemagick imagemagick-doc\n",
+        "\n",
+        "print(\"Finished installing dependencies.\")"
       ],
       "execution_count": 0,
       "outputs": []
@@ -279,7 +286,7 @@
         "%shell mkdir -p '{FRAME_OUTPUT_DIR}'\n",
         "%cd /content/DAIN\n",
         "\n",
-        "!python colab_interpolate.py --netName DAIN_slowmotion --time_step {fps/TARGET_FPS} --start_frame 1 --end_frame {pngs_generated_count} --frame_input_dir '{FRAME_INPUT_DIR}' --frame_output_dir '{FRAME_OUTPUT_DIR}'"
+        "!python -W ignore colab_interpolate.py --netName DAIN_slowmotion --time_step {fps/TARGET_FPS} --start_frame 1 --end_frame {pngs_generated_count} --frame_input_dir '{FRAME_INPUT_DIR}' --frame_output_dir '{FRAME_OUTPUT_DIR}'"
       ],
       "execution_count": 0,
       "outputs": []
@@ -341,7 +348,8 @@
         "%cd {FRAME_OUTPUT_DIR}\n",
         "%shell ffmpeg -i '/content/DAIN/{filename}' -acodec copy output-audio.aac\n",
         "%shell ffmpeg -y -r {TARGET_FPS} -f image2 -pattern_type glob -i '*.png' -i output-audio.aac -shortest '/content/gdrive/My Drive/{OUTPUT_FILE_PATH}'\n",
-        "if(AUTO_REMOVE==True):\n",
+        "\n",
+        "if (AUTO_REMOVE):\n",
         "  !rm -rf {FRAME_OUTPUT_DIR}/*\n",
         "  !rm -rf output-audio.aac"
       ],


### PR DESCRIPTION
Fixes #44.

## Detailed changes

- Minor updates on instructions to run the colab file
- Made the colab file install torch 1.4.0+cu100, torchvision 0.5.0+cu100 and scipy 1.1.0 (thanks @CyFeng16)
- Made the colab file clone the code from the official repo (this can now be done since the main changes are merged in it)
- Removed warning messages when running interpolation (thanks @CyFeng16)