### PR TITLE
Fix file naming for windows users & scipy version should be < 1.2.0

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
   - openssl=1.1.1=h7b6447c_0
   - pywavelets=1.0.1=py36hdd07704_0
   - scikit-image=0.14.1=py36he6710b0_0
-  - scipy=1.2.0=py36h7c811a0_0
+  - scipy=1.1.0=py36h7c811a0_0
   - toolz=0.9.0=py36_0
   - cycler=0.10.0=py_1
   - expat=2.2.5=hf484d3e_1002

--- a/my_args.py
+++ b/my_args.py
@@ -80,7 +80,7 @@ if args.uid == None:
     unique_id = str(numpy.random.randint(0, 100000))
     print("revise the unique id to a random numer " + str(unique_id))
     args.uid = unique_id
-    timestamp = datetime.datetime.now().strftime("%a-%b-%d-%H:%M")
+    timestamp = datetime.datetime.now().strftime("%a-%b-%d-%H-%M")
     save_path = './model_weights/'+ args.uid  +'-' + timestamp
 else:
     save_path = './model_weights/'+ str(args.uid)


### PR DESCRIPTION
Windows filesystem doesn't support ":" for folder or filenames.

scipy's ```imread``` function is deprecated in version 1.2.0