### PR TITLE
Fix seamless last frame detection

### DIFF
--- a/Colab_DAIN.ipynb
+++ b/Colab_DAIN.ipynb
@@ -29,11 +29,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "iGPHW5SOpPe3",
-        "colab_type": "text"
+        "id": "iGPHW5SOpPe3"
       },
       "source": [
-        "*DAIN Colab, v1.5.0*\n",
+        "*DAIN Colab, v1.5.1*\n",
         "\n",
         "Based on the [original Colab file](https://github.com/baowenbo/DAIN/issues/44) by btahir. \n",
         "\n",
@@ -307,7 +306,7 @@
         "if SEAMLESS:\n",
         "  frame_count += 1\n",
         "  first_frame = f\"{FRAME_INPUT_DIR}/00001.png\"\n",
-        "  new_last_frame = f\"{FRAME_INPUT_DIR}/{frame_count.zfill(5)}.png\"\n",
+        "  new_last_frame = f\"{FRAME_INPUT_DIR}/{str(frame_count).zfill(5)}.png\"\n",
         "  shutil.copyfile(first_frame, new_last_frame)\n",
         "\n",
         "print(f\"{frame_count} frame PNGs generated.\")"
@@ -402,8 +401,11 @@
         "colab": {}
       },
       "source": [
-        "if(AUTO_REMOVE):\n",
-        "  !rm -rf {FRAME_OUTPUT_DIR}/*"
+        "# [Experimental] Create video with sound\n",
+        "# Only run this, if the original had sound.\n",
+        "%cd {FRAME_OUTPUT_DIR}\n",
+        "%shell ffmpeg -i '/content/DAIN/{filename}' -acodec copy output-audio.aac\n",
+        "%shell ffmpeg -y -r {TARGET_FPS} -f image2 -pattern_type glob -i '*.png' -i output-audio.aac -shortest '/content/gdrive/My Drive/{OUTPUT_FILE_PATH}'"
       ],
       "execution_count": 0,
       "outputs": []
@@ -416,12 +418,6 @@
         "colab": {}
       },
       "source": [
-        "# [Experimental] Create video with sound\n",
-        "# Only run this, if the original had sound.\n",
-        "%cd {FRAME_OUTPUT_DIR}\n",
-        "%shell ffmpeg -i '/content/DAIN/{filename}' -acodec copy output-audio.aac\n",
-        "%shell ffmpeg -y -r {TARGET_FPS} -f image2 -pattern_type glob -i '*.png' -i output-audio.aac -shortest '/content/gdrive/My Drive/{OUTPUT_FILE_PATH}'\n",
-        "\n",
         "if (AUTO_REMOVE):\n",
         "  !rm -rf {FRAME_OUTPUT_DIR}/*\n",
         "  !rm -rf output-audio.aac"


### PR DESCRIPTION
The current codebase counted with the `frame_count` variable being a string, but that's not the case. This generated the error `AttributeError: 'int' object has no attribute 'zfill'` when using `SEAMLESS=true`.

This change fixes this error by performing a `str()` operation in that variable.

Fixes #115.